### PR TITLE
Editing capabilities after import

### DIFF
--- a/pyamll/components/carousel.py
+++ b/pyamll/components/carousel.py
@@ -2,6 +2,7 @@ from textual.app import ComposeResult
 from textual.widgets import Label, ListItem, ListView
 from textual.containers import Horizontal, Vertical
 from parser import VocalElement, Lyrics
+from parser.modify import ModificationType
 from enum import Enum
 from utils import convert_seconds_to_format as fsec
 
@@ -139,6 +140,18 @@ class Carousel(Horizontal):
         
         if active:
             self.active_item = new_item
+    
+    def rebuild(self) -> None:
+        operation = self.app.CURR_LYRICS.modification_stack[-1]
+        if operation._type == ModificationType.DELETE:
+            self.remove_children(".active") # Remove the current active element
+            # If first element then go to next element
+            if self.active_item.element.line_index == 0 and self.active_item.element.word_index == 0:
+                self.move(ScrollDirection.forward)
+            else:
+                self.move(ScrollDirection.backward)
+            # Else go back
+            
 
 
 class VerticalScroller(ListView):

--- a/pyamll/components/elementedit.py
+++ b/pyamll/components/elementedit.py
@@ -1,0 +1,32 @@
+from textual.app import ComposeResult
+from textual.containers import Grid
+from textual.screen import ModalScreen
+from textual.widgets import Button, Label, Input, Checkbox
+from parser import VocalElement
+from parser.modify import LyricModifyOperation, ModificationType
+
+class ElementEditModal(ModalScreen[LyricModifyOperation]):
+    """Screen with a dialog to edit a VocalElement."""
+    def __init__(self, element:VocalElement):
+        self.vocal_element = element
+        super().__init__()
+
+    def compose(self) -> ComposeResult:
+        yield Grid(
+            Label("Edit a VocalElement", id="element_edit_label"),
+            Input("", id="vocal_element_text"),
+            Checkbox("Is Explicit?", id="is_explicit_checkbox"),
+            Button("Delete Element", variant="error", id="delete"),
+            Button("Save", variant="primary"),
+            Button("Cancel", id="cancel"),
+            id="element-edit-dialog"
+        )
+
+    def on_mount(self) -> None:
+        self.query_one(Input).value = self.vocal_element.text
+
+    def on_button_pressed(self, event: Button.Pressed) -> None:
+        if event.button.id == "cancel":
+            self.dismiss()
+        elif event.button.id == "delete":
+            self.dismiss(LyricModifyOperation(ModificationType.DELETE, self.vocal_element))

--- a/pyamll/parser/modify.py
+++ b/pyamll/parser/modify.py
@@ -1,0 +1,37 @@
+from enum import Enum
+from parser import Lyrics, VocalElement
+
+class ModificationType(Enum):
+    EDIT = "edit"
+    DELETE = "delete"
+    APPEND = "append"
+
+class OperationStatus(Enum):
+    PENDING = "pending"
+    ONGOING = "ongoing"
+    EXEUTED = "executed"
+    FAILED = "failed"
+
+class LyricModifyOperation():
+    def __init__(self,_type:ModificationType, modified_element:VocalElement ,lyrics:Lyrics|None=None) -> None:
+        self._type = _type
+        self.lyrics = lyrics
+        self.status:OperationStatus = OperationStatus.PENDING
+        self.context:str = ""
+        self.modified_element = modified_element
+    
+    def execute(self) -> Lyrics:
+
+        if self._type == ModificationType.DELETE:
+            for mapping in self.lyrics.element_map:
+                i_element:VocalElement = mapping[0]
+                line = mapping[1]
+                word = mapping[2]
+                if (i_element.line_index, i_element.word_index) == (self.modified_element.line_index, self.modified_element.word_index):
+                    break
+            
+            self.lyrics.init_list[line].elements[word] = None
+        
+        self.lyrics.rebuild()
+        self.status = OperationStatus.EXEUTED
+        return self.lyrics

--- a/pyamll/styles/elementedit.tcss
+++ b/pyamll/styles/elementedit.tcss
@@ -1,0 +1,38 @@
+ElementEditModal {
+    align: center middle;
+}
+
+#element-edit-dialog {
+    grid-size: 2;
+    grid-rows: 1fr 3;
+    border: thick $background 80%;
+    background: $surface;
+    padding: 0 1;
+    width: 60;
+    height: 20;
+    grid-gutter: 1 2;
+}
+
+#element_edit_label {
+    column-span: 2;
+    width: 1fr;
+    margin-top: 1;
+    content-align: center middle;
+}
+
+#vocal_element_text {
+    column-span: 2;
+}
+
+#is_explicit_checkbox {
+    column-span: 2;
+    width: 1fr;
+}
+
+#element-edit-dialog > Button {
+    width: 1fr;
+}
+
+#element-edit-dialog > #delete {
+    column-span: 2;
+}

--- a/pyamll/tui.py
+++ b/pyamll/tui.py
@@ -17,6 +17,7 @@ class TTMLApp(App):
         "styles/sidebar.tcss",
         "styles/carousel.tcss",
         "styles/playerbox.tcss",
+        "styles/elementedit.tcss",
     ]
 
     CURR_LYRICS: Lyrics = None


### PR DESCRIPTION
Adds ability to edit vocal elements after importing them from a text file. This allows for the following

- [x] Deleting elements
- [ ] Editing element text
- [ ] Splitting elements
- [ ] Changing order of elements
- [ ] Line reset if manually edited

Closes #9 