### PR TITLE
Rework Object Handling

### DIFF
--- a/pyamll/parser/__init__.py
+++ b/pyamll/parser/__init__.py
@@ -10,9 +10,9 @@ class Vocal(Enum):
 
 @dataclass
 class VocalElement:
-    word_index: int
     text: str
     line_index:int
+    is_part_of_word:bool = False
     is_explicit: bool = False
     start_time: float = 0
     end_time: float = 0
@@ -47,13 +47,14 @@ class Line:
     def __str__(self):
         _str = ""
 
-        index = 0
+        part_of_word = False
         for i in range(len(self.elements)):
-            if self.elements[i].word_index > index:
-                _str += " "
-                index = self.elements[i].word_index
             _str += str(self.elements[i])
-        return _str
+            part_of_word = self.elements[i].is_part_of_word
+            if not part_of_word:
+                _str+=" "
+
+        return _str.strip()
     
 class Lyrics(list):
     element_map = []
@@ -105,13 +106,15 @@ def process_lyrics(lyrics_str:str) -> Lyrics:
             if word.strip() == "":
                 continue
 
+            # if / in word like heart/beat then the first word will have the bool but not last
             if '/' in word:
                 syllables = word.split('/')
                 for syllable_counter in range(len(syllables)):
-                    line.elements.append(VocalElement(word_index=word_counter, text=syllables[syllable_counter], line_index=len(line_objects)))
+                    line.elements.append(
+                        VocalElement(text=syllables[syllable_counter], is_part_of_word=(syllable_counter != len(syllables)-1) ,line_index=len(line_objects)))
                 continue
             
-            line.elements.append(VocalElement(word_index=word_counter, text=word, line_index=len(line_objects)))
+            line.elements.append(VocalElement(text=word, line_index=len(line_objects)))
 
         line_objects.append(line)
     return Lyrics(line_objects)

--- a/pyamll/parser/swlrc.py
+++ b/pyamll/parser/swlrc.py
@@ -19,17 +19,12 @@ def export_as_swlrc(lyrics:Lyrics) -> dict:
     for line in lyrics.init_list:
         line:Line = line
         _lead_list = []
-        for i,element in enumerate(line.elements):
+        for element in line.elements:
             element:VocalElement = element
-            _is_part_of_word = False
-            try:
-                if line.elements[i+1].word_index == element.word_index:
-                    _is_part_of_word = True
-            except IndexError:
-                pass            
+         
             _lead_list.append({
                 "Text": element.text,
-                    "IsPartOfWord": _is_part_of_word,
+                    "IsPartOfWord": element.is_part_of_word,
                     "StartTime": element.start_time,
                     "EndTime": element.end_time
             })


### PR DESCRIPTION
Simplifies code in `pyamll/parser/__init__.py` as well as accessing VocalElements

- [x] Replace `word_index` with `is_part_of_word`
- [ ] Remove `line_index` from VocalElements and use nested lists
- [ ] Remove elements from Lines
- [ ] Implement get_element methods